### PR TITLE
add 福岡 愛信園 to facility pulldown list

### DIFF
--- a/src/containers/Welcome/Step1/Step1.tsx
+++ b/src/containers/Welcome/Step1/Step1.tsx
@@ -32,7 +32,7 @@ import {
   LogoWhiteBG,
 } from '../style';
 
-const facilityList = ['福岡 さんすまいる唐原', '福岡 藤の実会', '福井 笑楽日', 'その他'];
+const facilityList = ['福岡 愛信園', '福岡 さんすまいる唐原', '福岡 藤の実会', '福井 笑楽日', 'その他'];
 
 const facilityOptions = facilityList.map(facility => ({ label: facility, value: facility }));
 


### PR DESCRIPTION
Ill pull myself. (Because it is not a significant change)

add `福岡 愛信園`

before:
['福岡 さんすまいる唐原', '福岡 藤の実会', '福井 笑楽日', 'その他']

after:
['福岡 愛信園', '福岡 さんすまいる唐原', '福岡 藤の実会', '福井 笑楽日', 'その他']
(lexicographical ordered)